### PR TITLE
Refactor and minor fixes

### DIFF
--- a/prompt_guardian/server.py
+++ b/prompt_guardian/server.py
@@ -140,7 +140,7 @@ def check_threats(prompt: str, class_instance):
 
 
 @prompt_guardian_app.post("/check-prompt")
-async def check_url(prompt_check_request: PromptCheckRequest, request: Request):
+async def check_prompt(prompt_check_request: PromptCheckRequest, request: Request):
     prompt = prompt_check_request.text
     url_manager = request.app.state.url_manager
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "prompt_guardian"
-version = "0.1.3"
+version = "0.1.4"
 description = ""
 authors = ["BenderScript <6779302+BenderScript@users.noreply.github.com>"]
 license = "Apache 2.0"

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -30,7 +30,7 @@ class TestFastAPIApp(unittest.TestCase):
         await self.add_remove_url(test_url, add=True)
 
         # Test the URL
-        response = await self.client.post("/check-url", json={"url": test_url})
+        response = await self.client.post("/check-prompt", json={"url": test_url})
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"result": "URL is in the abuse list"})
 
@@ -39,7 +39,7 @@ class TestFastAPIApp(unittest.TestCase):
 
     async def test_check_url_not_in_abuse_list(self):
         test_url = "http://example.com/safe"  # Replace with a URL not in your abuse list
-        response = await self.client.post("/check-url", json={"url": test_url})
+        response = await self.client.post("/check-prompt", json={"url": test_url})
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"result": "URL is not in the abuse list"})
 


### PR DESCRIPTION
- Change handler name from "check_url" to "check_prompt" so it matches what the handler is doing
- Break down the functionalities within the handler to 4 different utility functions:
  - `check_url_status()`
  - `check_openai_prompt_status()`
  - `check_gemini_prompt_status()`
  - `check_gemini_prompt_status()`
- Fix minor bug that results in having `Threats: D, L, P,  , D, i, s, a, b, l, e, d` in the response when umbrella is disabled

Example output with the changes in this PR:

- When DLP is enabled and there are threats:
```
{'prompt_injection': {'openai': 'OpenAI Prompt Injection Detection disabled', 'gemini': 'Gemini Prompt Injection Detection disabled'}, 'url_verdict': 'No Malware URL(s)', 'threats': 'Medical Prescriptions (US), Email Address'}
```

- When DLP is disabled or no threats:
```
{'prompt_injection': {'openai': 'OpenAI Prompt Injection Detection disabled', 'gemini': 'Gemini Prompt Injection Detection disabled'}, 'url_verdict': 'Malware URL(s)', 'threats': 'No Threats Detected or DLP Disabled'}
```