### PR TITLE
Allow clients to select which functions to use in the request

### DIFF
--- a/prompt_guardian/server.py
+++ b/prompt_guardian/server.py
@@ -208,12 +208,12 @@ async def check_prompt(prompt_check_request: CheckPromptRequest, request: Reques
     prompt = prompt_check_request.text
     url_manager = request.app.state.url_manager
 
-    # Initialize status variables to None as the default values
-    url_status = ""
-    openai_prompt_status = ""
-    gemini_prompt_status = ""
-    azure_prompt_status = ""
-    threats = ""
+    # default statuses - these will be returned to the client when the functionalities are not selected in the request
+    url_status = "Prompt check for malware URLs is disabled per client request"
+    openai_prompt_status = "Prompt injection detection with OpenAI is disabled per client request"
+    gemini_prompt_status = "Prompt injection detection with Gemini is disabled per client request"
+    azure_prompt_status = "Prompt injection detection with Azure is disabled per client request"
+    threats = "Prompt check for DLP wit Umbrella is disabled per client request"
 
     if prompt_check_request.check_url:
         if url_manager.enabled:


### PR DESCRIPTION
Added **optional** parameters in the request to allow clients to select which checks they'd like the server to run, example request body:

```json
{
	"text": "test",
	"extractedUrls": [],
	"check_url": true,
	"check_openai": false,
	"check_gemini": false,
	"check_azure": false,
	"check_threats": false
}
```

Corresponding response:

```json
{
	"prompt_injection": {
		"azure": "Prompt injection detection with Azure is disabled per user request",
		"gemini": "Prompt injection detection with Gemini is disabled per user request",
		"openai": "Prompt injection detection with OpenAI is disabled per user request"
	},
	"url_verdict": "No malware URL(s) detected",
	"threats": "Prompt check for DLP wit Umbrella is disabled per user request"
}
```